### PR TITLE
Bugfix - Readme 3D example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ shift[:NAM] = dx
 shift[:PAM] = dx
 shift[:CC] = dx
 shift[:PP] = dx
-plot_multimodel_interactive(model, states, shift = shift, colormap = :curl)
+plot_multimodel_interactive(extra[:model], states, shift = shift, colormap = :curl)
 ```
 ![3D plot](docs/src/assets/3d_plot.png)
 


### PR DESCRIPTION
Caught this bug while looking through the examples. The easy fix is to grab the model definition from the `extra` dictionary, there might be an alternative method that better aligns with the codebase, however.