### PR TITLE
Avoid ForwardDiff 1.0 temporarily

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 x264_jll = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
 
 [compat]
+ForwardDiff = "0.10.38"
 JLD2 = "0.4.31"
 JSON = "0.21.4"
 Jutul = "0.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 x264_jll = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-
-[extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 x264_jll = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
 
+[extras]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
 [compat]
 ForwardDiff = "0.10.38"
 JLD2 = "0.4.31"


### PR DESCRIPTION
ForwardDiff 1.0 is now allowed by Jutul, but this gives singular systems. Probably some comparison somewhere should use value instead of direct checking, since this is the major change in ForwardDiff 1.0 (see https://github.com/JuliaDiff/ForwardDiff.jl/pull/481).

For the time being, set compat to the old version.