### PR TITLE
Temperature dependence reaction rate and electrode diffusion coefficient

### DIFF
--- a/docs/src/public/notebooks/10_handling_grid_time_resolution.ipynb
+++ b/docs/src/public/notebooks/10_handling_grid_time_resolution.ipynb
@@ -1,0 +1,352 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# How to change time and grid resolution in BattMo\n",
+    "\n",
+    "Until now we have seen three different input types that can be used to define a simulation in BattMo:\n",
+    "- CellParameters : defines the physical and chemical properties of the battery cell\n",
+    "- CyclingProtocol : defines the current/voltage profile that the cell is subjected to during the simulation\n",
+    "- ModelSettings :   defines various settings for the battery model, such as which submodels to use\n",
+    "\n",
+    "In addition to these, there is a fourth input type called SimulationSettings.\n",
+    "These settings allow you to control the time step and grid resolution for your simulations.\n",
+    "This can be useful for balancing accuracy and computational cost.\n",
+    "\n",
+    "Let's see how to change these settings."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "using BattMo, GLMakie"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load cell parameters as before"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "cell_parameters = load_cell_parameters(; from_default_set = \"Chen2020\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To demonstrate changing time resolution we will use a drive cycle to setup a current function."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Create wltp function to calculate Current (WLTP data from https://github.com/JRCSTU/wltp)"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "using CSV\n",
+    "using DataFrames\n",
+    "using Jutul\n",
+    "\n",
+    "data_path = string(dirname(pathof(BattMo)), \"/../examples/example_data/\")\n",
+    "path = joinpath(data_path, \"wltp.csv\")\n",
+    "\n",
+    "df = CSV.read(path, DataFrame)\n",
+    "\n",
+    "t = df[:, 1]\n",
+    "P = df[:, 2]\n",
+    "\n",
+    "power_func = get_1d_interpolator(t, P, cap_endpoints = false)\n",
+    "\n",
+    "\n",
+    "function current_function(time, voltage)\n",
+    "\n",
+    "\tfactor = 4000 # Tot account for the fact that we're simulating a single cell instead of a battery pack\n",
+    "\n",
+    "\treturn power_func(time) / voltage / factor\n",
+    "end\n",
+    "\n",
+    "@eval Main current_function = $current_function"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load a cycling protocol that uses the current function"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "cycling_protocol = load_cycling_protocol(; from_default_set = \"user_defined_current_function\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Plot the drive data to see what we are simulating"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "fig = Figure(size = (1000, 400))\n",
+    "ax = Axis(fig[1, 1], title = \"Drive cycle\", xlabel = \"Time / s\", ylabel = \"Power / W\")\n",
+    "lines!(ax, t, P)\n",
+    "fig"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Load default simulation settings for the P2D model"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "simulation_settings = load_simulation_settings(; from_default_set = \"P2D\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "run the simulation"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "model = LithiumIonBattery()\n",
+    "sim = Simulation(model, cell_parameters, cycling_protocol; simulation_settings)\n",
+    "output = solve(sim;)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Plot the results"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "plot_dashboard(output)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see from the plot that the time resolution is way too low to capture the dynamics of the drive cycle.\n",
+    "We can change the time resolution by modifying the simulation settings. Let's see which simulation setting is available that has to do with time."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "print_setting_info(\"time\"; category = \"SimulationSettings\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see that the time step can be controlled by TimeStepDuration."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "simulation_settings[\"TimeStepDuration\"] = 1.0 # Set the initial time step duration to 1 second"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now let's rerun the simulation with the new time step duration and plot the results."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "sim = Simulation(model, cell_parameters, cycling_protocol; simulation_settings)\n",
+    "output = solve(sim;)\n",
+    "plot_dashboard(output)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see that the time resolution is much better now and we can capture the dynamics of the drive cycle."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can also plot the concentrations and potentials in the cell to see how they change over time and position.\n",
+    "Let's plot them as line plots over position so we can have a look at the grid resolution."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "plot_dashboard(output; plot_type = \"line\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now scrol the bar at the bottom of the window the change the time step to see how the concentrations and potentials change over time.\n",
+    "For most time steps, we can see that the electrolyte concentration and positive electrode surface concentration over position are not smooth.\n",
+    "This is because the grid resolution of the separator and positive electrode is too low to capture the concentration gradient.\n",
+    "We can change the grid resolution by modifying the simulation settings. Let's see which simulation setting is available that changes the positive electrode coating thickness grid resolution."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "print_setting_info(\"PositiveElectrode\"; category = \"SimulationSettings\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "And the separator grid resolution."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "print_setting_info(\"Separator\"; category = \"SimulationSettings\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see that the grid resolutions can be controlled by GridResolutionPositiveElectrodeCoating and GridResolutionSeparator."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Lets have a look at the current grid resolutions and increase them."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "println(\"Current grid resolution in positive electrode coating and separator: \",\n",
+    "\tsimulation_settings[\"GridResolutionPositiveElectrodeCoating\"],\n",
+    "\t\" and \",\n",
+    "\tsimulation_settings[\"GridResolutionSeparator\"])\n",
+    "\n",
+    "simulation_settings[\"GridResolutionPositiveElectrodeCoating\"] = 20 # Increase the grid resolution in the positive electrode coating to 20\n",
+    "simulation_settings[\"GridResolutionNegativeElectrodeCoating\"] = 20 # Increase the grid resolution in the separator to 10\n",
+    "\n",
+    "#Let's rerun the simulation with the new grid resolution and plot the results.\n",
+    "sim = Simulation(model, cell_parameters, cycling_protocol; simulation_settings)\n",
+    "output = solve(sim;)\n",
+    "plot_dashboard(output; plot_type = \"line\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see that the electrolyte concentration and positive electrode surface concentration over position are now smooth."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "---\n",
+    "\n",
+    "*This notebook was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*"
+   ],
+   "metadata": {}
+  }
+ ],
+ "nbformat_minor": 3,
+ "metadata": {
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.11.3"
+  },
+  "kernelspec": {
+   "name": "julia-1.11",
+   "display_name": "Julia 1.11.3",
+   "language": "julia"
+  }
+ },
+ "nbformat": 4
+}

--- a/docs/src/public/notebooks/11_handling_solver_settings.ipynb
+++ b/docs/src/public/notebooks/11_handling_solver_settings.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# How to change solver related settings in BattMo\n",
+    "\n",
+    "Until now we have seen four different input types that can be used to define a simulation in BattMo:\n",
+    "- CellParameters : defines the physical and chemical properties of the battery cell\n",
+    "- CyclingProtocol : defines the current/voltage profile that the cell is subjected to during the simulation\n",
+    "- ModelSettings :   defines various settings for the battery model, such as which submodels to use\n",
+    "- SimulationSettings : defines the time step and grid resolution for your simulations\n",
+    "\n",
+    "In addition to these, there is a fifth input type called SolverSettings.\n",
+    "These settings allow you to control various aspects of the numerical solver used in BattMo.\n",
+    "This can be useful for improving convergence, stability, and performance of the simulations.\n",
+    "But as a beginner, just learning how to use BattMo, for most solver settings you'll stick with the default settings.\n",
+    "Therefore, we will not go into detail about all the available options here, but just show how to load and modify the solver settings\n",
+    "for a couple of specific settings that can be very useful and handy for every user.\n",
+    "\n",
+    "Let's get into it."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "using BattMo, GLMakie"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Just like we can load the default cell parameters, cycling protocol, model settings, and simulation settings,\n",
+    "we can also load the default solver settings."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "solver_settings = load_solver_settings(; from_default_set = \"default\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Lets setup a simple simulation to demonstrate the solver settings."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "cell_parameters = load_cell_parameters(; from_default_set = \"Chen2020\")\n",
+    "cycling_protocol = load_cycling_protocol(; from_default_set = \"CCDischarge\")\n",
+    "\n",
+    "model = LithiumIonBattery()\n",
+    "sim = Simulation(model, cell_parameters, cycling_protocol)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As the solver settings tell the solver how to solve the simulation object, we need to pass the solver settings to the solve function."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "output = solve(sim; solver_settings)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The simulation should run just like before, but now we have the option to modify the solver settings.\n",
+    "One useful setting is that we can set an output path that will save the simulation output to an HDF5 file.\n",
+    "This can be useful if you are running long simulations and want to save the output for later analysis.\n",
+    "By default, the output is not saved to a file, but we can change that by setting the OutputPath field in the solver settings."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "solver_settings[\"OutputPath\"] = \"example_path/\"\n",
+    "try # hide\n",
+    "\toutput = solve(sim; solver_settings)\n",
+    "catch e # hide\n",
+    "\t@warn \"Expected to fail because the path does not exist\" exception = e # hide\n",
+    "end # hide\n",
+    "nothing # hide"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Another convenient setting is the option to change the amount of information printed to the console during the simulation. For this we use the setting \"InfoLevel\".\n",
+    "This can be useful for monitoring the progress of the simulation, and debugging purposes. Or on the contrary, if you want to run a simulation without any output to the console, you can set the value to -1.\n",
+    "Let's have a look at the description of the setting to see the available options."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "print_setting_info(\"InfoLevel\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As you can see, the default value is 0, which gives minimal output (just a progress bar by default, and a final report)."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To have a look at the other available settings, you can print them all like this:"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "print_setting_info(\"\"; category = \"SolverSettings\")"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As most of the time we'll only change one or two settings, and we use some of the settings often temporary, BattMo also has the option to\n",
+    "pass the solver settings directly to the solve function, without having to create a SolverSettings object first.\n",
+    "This can be useful for quick tests, or if you want to change a setting for a single simulation only. In that case you have to pass them\n",
+    "as keyword arguments to the solve function. Because of convention, we use snake_case for the keyword arguments, instead of the usual CamelCase used in the SolverSettings object.\n",
+    "The snake_case name is just the CamelCase name with the first letter lowercased and the low dash in between, if you're unsure, you can find the\n",
+    "correct name by printing the setting info as shown above."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [],
+   "cell_type": "code",
+   "source": [
+    "output = solve(sim; info_level = 2)"
+   ],
+   "metadata": {},
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "These keywork arguments will override the settings in the SolverSettings object, if both are provided."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "---\n",
+    "\n",
+    "*This notebook was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*"
+   ],
+   "metadata": {}
+  }
+ ],
+ "nbformat_minor": 3,
+ "metadata": {
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.11.3"
+  },
+  "kernelspec": {
+   "name": "julia-1.11",
+   "display_name": "Julia 1.11.3",
+   "language": "julia"
+  }
+ },
+ "nbformat": 4
+}

--- a/docs/src/public/notebooks/1_useful_tools.ipynb
+++ b/docs/src/public/notebooks/1_useful_tools.ipynb
@@ -211,7 +211,8 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "cell_parameters = load_cell_parameters(; from_default_set = \"Chen2020\")"
+    "cell_parameters = load_cell_parameters(; from_default_set = \"Chen2020\")\n",
+    "nothing # hide"
    ],
    "metadata": {},
    "execution_count": null

--- a/examples/beginner_tutorials/10_handling_grid_time_resolution.jl
+++ b/examples/beginner_tutorials/10_handling_grid_time_resolution.jl
@@ -1,9 +1,9 @@
 # # How to change time and grid resolution in BattMo
 #
 # Until now we have seen three different input types that can be used to define a simulation in BattMo:
-# - CellParameters : defines the physical and chemical properties of the battery cell
-# - CyclingProtocol : defines the current/voltage profile that the cell is subjected to during the simulation
-# - ModelSettings :   defines various settings for the battery model, such as which submodels to use
+# - *CellParameters* : defines the physical and chemical properties of the battery cell
+# - *CyclingProtocol* : defines the current/voltage profile that the cell is subjected to during the simulation
+# - *ModelSettings* :   defines various settings for the battery model, such as which submodels to use
 #
 # In addition to these, there is a fourth input type called SimulationSettings.
 # These settings allow you to control the time step and grid resolution for your simulations.
@@ -15,6 +15,7 @@ using BattMo, GLMakie
 
 # Load cell parameters as before
 cell_parameters = load_cell_parameters(; from_default_set = "Chen2020")
+nothing # hide
 
 # To demonstrate changing time resolution we will use a drive cycle to setup a current function.
 
@@ -24,7 +25,9 @@ using CSV
 using DataFrames
 using Jutul
 
-path = joinpath(@__DIR__, "../example_data/wltp.csv")
+data_path = string(dirname(pathof(BattMo)), "/../examples/example_data/")
+path = joinpath(data_path, "wltp.csv")
+
 df = CSV.read(path, DataFrame)
 
 t = df[:, 1]
@@ -44,6 +47,7 @@ end
 
 # Load a cycling protocol that uses the current function
 cycling_protocol = load_cycling_protocol(; from_default_set = "user_defined_current_function")
+nothing # hide
 
 # Plot the drive data to see what we are simulating
 fig = Figure(size = (1000, 400))
@@ -53,11 +57,13 @@ fig
 
 # Load default simulation settings for the P2D model
 simulation_settings = load_simulation_settings(; from_default_set = "P2D")
+nothing # hide
 
 # run the simulation
 model = LithiumIonBattery()
 sim = Simulation(model, cell_parameters, cycling_protocol; simulation_settings)
 output = solve(sim;)
+nothing # hide
 
 # Plot the results
 plot_dashboard(output)
@@ -85,22 +91,22 @@ plot_dashboard(output; plot_type = "line")
 
 # Now scrol the bar at the bottom of the window the change the time step to see how the concentrations and potentials change over time.
 # For most time steps, we can see that the electrolyte concentration and positive electrode surface concentration over position are not smooth.
-# This is because the grid resolution of the separator and positive electrode is too low to capture the concentration gradient.
-# We can change the grid resolution by modifying the simulation settings. Let's see which simulation setting is available that changes the positive electrode coating thickness grid resolution.
+# This is because the grid resolution of the negative and positive electrode are too low to capture the concentration gradient.
+# We can change the grid resolution by modifying the simulation settings. Let's see which simulation setting is available that changes the negative and positive electrode coating thickness grid resolution.
 
 print_setting_info("PositiveElectrode"; category = "SimulationSettings")
 
-# And the separator grid resolution.
+# And the negative electrode grid resolution.
 
-print_setting_info("Separator"; category = "SimulationSettings")
+print_setting_info("NegativeElectrode"; category = "SimulationSettings")
 
-# We can see that the grid resolutions can be controlled by GridResolutionPositiveElectrodeCoating and GridResolutionSeparator.
+# We can see that the grid resolutions can be controlled by GridResolutionPositiveElectrodeCoating and GridResolutionNegativeElectrodeCoating.
 
 # Lets have a look at the current grid resolutions and increase them.
 println("Current grid resolution in positive electrode coating and separator: ",
 	simulation_settings["GridResolutionPositiveElectrodeCoating"],
 	" and ",
-	simulation_settings["GridResolutionSeparator"])
+	simulation_settings["GridResolutionNegativeElectrodeCoating"])
 
 simulation_settings["GridResolutionPositiveElectrodeCoating"] = 20 # Increase the grid resolution in the positive electrode coating to 20
 simulation_settings["GridResolutionNegativeElectrodeCoating"] = 20 # Increase the grid resolution in the separator to 10

--- a/examples/beginner_tutorials/11_handling_solver_settings.jl
+++ b/examples/beginner_tutorials/11_handling_solver_settings.jl
@@ -1,10 +1,10 @@
 # # How to change solver related settings in BattMo
 #
 # Until now we have seen four different input types that can be used to define a simulation in BattMo:
-# - CellParameters : defines the physical and chemical properties of the battery cell
-# - CyclingProtocol : defines the current/voltage profile that the cell is subjected to during the simulation
-# - ModelSettings :   defines various settings for the battery model, such as which submodels to use
-# - SimulationSettings : defines the time step and grid resolution for your simulations
+# - *CellParameters* : defines the physical and chemical properties of the battery cell
+# - *CyclingProtocol* : defines the current/voltage profile that the cell is subjected to during the simulation
+# - *ModelSettings* :   defines various settings for the battery model, such as which submodels to use
+# - *SimulationSettings* : defines the time step and grid resolution for your simulations
 #
 # In addition to these, there is a fifth input type called SolverSettings.
 # These settings allow you to control various aspects of the numerical solver used in BattMo.
@@ -20,6 +20,7 @@ using BattMo, GLMakie
 # Just like we can load the default cell parameters, cycling protocol, model settings, and simulation settings,
 # we can also load the default solver settings.
 solver_settings = load_solver_settings(; from_default_set = "default")
+nothing # hide
 
 # Lets setup a simple simulation to demonstrate the solver settings.
 
@@ -28,9 +29,11 @@ cycling_protocol = load_cycling_protocol(; from_default_set = "CCDischarge")
 
 model = LithiumIonBattery()
 sim = Simulation(model, cell_parameters, cycling_protocol)
+nothing # hide
 
 # As the solver settings tell the solver how to solve the simulation object, we need to pass the solver settings to the solve function.
 output = solve(sim; solver_settings)
+nothing # hide
 # The simulation should run just like before, but now we have the option to modify the solver settings.
 # One useful setting is that we can set an output path that will save the simulation output to an HDF5 file.
 # This can be useful if you are running long simulations and want to save the output for later analysis.
@@ -39,6 +42,7 @@ output = solve(sim; solver_settings)
 solver_settings["OutputPath"] = "example_path/"
 try # hide
 	output = solve(sim; solver_settings)
+	nothing # hide
 catch e # hide
 	@warn "Expected to fail because the path does not exist" exception = e # hide
 end # hide
@@ -62,5 +66,6 @@ print_setting_info(""; category = "SolverSettings")
 # correct name by printing the setting info as shown above.
 
 output = solve(sim; info_level = 2)
+nothing # hide
 
 # These keywork arguments will override the settings in the SolverSettings object, if both are provided.

--- a/src/BattMo.jl
+++ b/src/BattMo.jl
@@ -214,6 +214,7 @@ include("input/validator.jl")
 
 
 include("models/thermal.jl")
+include("models/temperature_dependence.jl")
 include("models/elyte.jl")
 include("models/current_collector.jl")
 include("models/ocp.jl")

--- a/src/input/defaults/cycling_protocols/CCCV.json
+++ b/src/input/defaults/cycling_protocols/CCCV.json
@@ -12,6 +12,5 @@
   "UpperVoltageLimit": 4.0,
   "InitialControl": "charging",
   "CurrentChangeLimit": 1e-4,
-  "VoltageChangeLimit": 1e-4,
-  "InitialTemperature": 298.15
+  "VoltageChangeLimit": 1e-4
 }

--- a/src/input/defaults/cycling_protocols/CCCharge.json
+++ b/src/input/defaults/cycling_protocols/CCCharge.json
@@ -9,6 +9,5 @@
   "CRate": 0.5,
   "LowerVoltageLimit": 2.5,
   "UpperVoltageLimit": 4.1,
-  "InitialControl": "charging",
-  "InitialTemperature": 298.15
+  "InitialControl": "charging"
 }

--- a/src/input/defaults/cycling_protocols/CCCycling.json
+++ b/src/input/defaults/cycling_protocols/CCCycling.json
@@ -10,6 +10,5 @@
     "DRate": 0.5,
     "LowerVoltageLimit": 2.5,
     "UpperVoltageLimit": 4.1,
-    "InitialControl": "charging",
-    "InitialTemperature": 298.15
+    "InitialControl": "charging"
 }

--- a/src/input/defaults/cycling_protocols/CCDischarge.json
+++ b/src/input/defaults/cycling_protocols/CCDischarge.json
@@ -9,6 +9,5 @@
   "InitialControl": "discharging",
   "DRate": 0.5,
   "LowerVoltageLimit": 2.4,
-  "UpperVoltageLimit": 4.1,
-  "InitialTemperature": 298.15
+  "UpperVoltageLimit": 4.1
 }

--- a/src/input/defaults/cycling_protocols/user_defined_current_function.json
+++ b/src/input/defaults/cycling_protocols/user_defined_current_function.json
@@ -6,6 +6,5 @@
     "Protocol": "Function",
     "FunctionName": "current_function",
     "InitialStateOfCharge": 0.99,
-    "TotalTime": 1800,
-    "InitialTemperature": 298.15
+    "TotalTime": 1800
 }

--- a/src/input/formatter.jl
+++ b/src/input/formatter.jl
@@ -349,7 +349,7 @@ function convert_old_input_format_to_parameter_sets(params::BattMoInputFormatOld
 		"DRate" => params["Control"]["DRate"],
 		"LowerVoltageLimit" => params["Control"]["lowerCutoffVoltage"],
 		"UpperVoltageLimit" => params["Control"]["upperCutoffVoltage"],
-		"InitialTemperature" => params["initT"],
+		"AmbientTemperature" => params["initT"],
 		"InitialControl" => init_prot,
 	)
 

--- a/src/input/meta_data/settings.jl
+++ b/src/input/meta_data/settings.jl
@@ -40,6 +40,13 @@ function get_setting_meta_data()
 			"documentation" => "https://battmoteam.github.io/BattMo.jl/dev/manuals/user_guide/pxd_model",
 			"description" => """When set to Chayambuka, the slightly adapted butler volmer equation from reference [Chayambuka2020](https://www.sciencedirect.com/science/article/pii/S0013468621020478?via%3Dihub) will be selected within the model.""",
 		),
+		"TemperatureDependence" => Dict(
+			"type" => String,
+			"options" => ["Arrhenius"],
+			"category" => "ModelSettings",
+			"documentation" => "",
+			"description" => """Temperature dependence model for electrode diffusion coefficients and reaction rates. Example: "Arrhenius".""",
+		),
 		"TransportInSolid" => Dict(
 			"type" => String,
 			"options" => ["FullDiffusion"],

--- a/src/input/schemas/get_schema.jl
+++ b/src/input/schemas/get_schema.jl
@@ -353,7 +353,6 @@ function get_schema_cell_parameters(model_settings::ModelSettings)
 
 		push!(cell_required, "ElectrodeWidth")
 		push!(cell_required, "ElectrodeLength")
-		push!(cell_required, "ElectrodeGeometricSurfaceArea")
 		if haskey(model_settings, "CurrentCollectors")
 			push!(ne_required, "CurrentCollector")
 			push!(pe_required, "CurrentCollector")

--- a/src/input/schemas/get_schema.jl
+++ b/src/input/schemas/get_schema.jl
@@ -390,10 +390,10 @@ function get_schema_cell_parameters(model_settings::ModelSettings)
 end
 
 
-function get_schema_cycling_protocol()
+function get_schema_cycling_protocol(model_settings::ModelSettings)
 	# Retrieve meta-data for validation
 	parameter_meta = get_parameter_meta_data()
-	return Dict(
+	schema = Dict(
 		"\$schema" => "http://json-schema.org/draft-07/schema#",
 		"type" => "object",
 		"properties" => Dict(
@@ -427,7 +427,6 @@ function get_schema_cycling_protocol()
 						"UpperVoltageLimit",
 						"CurrentChangeLimit",
 						"VoltageChangeLimit",
-						"InitialTemperature",
 					]),
 			),
 			Dict(
@@ -447,7 +446,6 @@ function get_schema_cycling_protocol()
 						"InitialStateOfCharge",
 						"FunctionName",
 						"TotalTime",
-						"InitialTemperature",
 					],
 				),
 			),
@@ -460,7 +458,6 @@ function get_schema_cycling_protocol()
 						"InitialStateOfCharge",
 						"DRate",
 						"LowerVoltageLimit",
-						"InitialTemperature",
 					]),
 			),
 			Dict(
@@ -474,7 +471,6 @@ function get_schema_cycling_protocol()
 						"TotalNumberOfCycles",
 						"CRate",
 						"UpperVoltageLimit",
-						"InitialTemperature",
 					]),
 			),
 			Dict(
@@ -487,11 +483,18 @@ function get_schema_cycling_protocol()
 						"DRate",
 						"UpperVoltageLimit",
 						"LowerVoltageLimit",
-						"InitialTemperature",
 					]),
 			),
 		],
 	)
+	required = schema["required"]
+	temperature_dependence = get(model_settings, "TemperatureDependence", nothing)
+
+	if temperature_dependence == "Arrhenius"
+		push!(required, "AmbientTemperature")
+	end
+
+	return schema
 end
 
 
@@ -658,6 +661,7 @@ function get_schema_model_settings()
 			"TransportInSolid" => create_property(parameter_meta, "TransportInSolid"),
 			"ButlerVolmer" => create_property(parameter_meta, "ButlerVolmer"),
 			"PotentialFlowDiscretization" => create_property(parameter_meta, "PotentialFlowDiscretization"),
+			"TemperatureDependence" => create_property(parameter_meta, "TemperatureDependence"),
 		),
 		"required" => [
 			"ModelFramework", "TransportInSolid", "PotentialFlowDiscretization", "ButlerVolmer",

--- a/src/input/schemas/lithium_ion/CyclingProtocol.json
+++ b/src/input/schemas/lithium_ion/CyclingProtocol.json
@@ -27,7 +27,7 @@
             ],
             "description": "Whether a cycling protocol starts with 'charging' or 'discharging'."
         },
-        "InitialTemperature": {
+        "AmbientTemperature": {
             "type": "number",
             "minimum": 238.15,
             "maximum": 373.15,
@@ -126,7 +126,7 @@
     "required": [
         "Protocol",
         "InitialStateOfCharge",
-        "InitialTemperature"
+        "AmbientTemperature"
     ],
     "allOf": [
         {

--- a/src/input/validator.jl
+++ b/src/input/validator.jl
@@ -129,9 +129,9 @@ function validate_parameter_set(parameters::ModelSettings)
 
 end
 
-function validate_parameter_set(parameters::CyclingProtocol)
+function validate_parameter_set(parameters::CyclingProtocol, model_settings::ModelSettings)
 
-	schema = get_schema_cycling_protocol()
+	schema = get_schema_cycling_protocol(model_settings)
 
 	# Convert schema Dict to JSONSchema object
 	schema_obj = Schema(schema)

--- a/src/matlab_interface/matlab_model_setup.jl
+++ b/src/matlab_interface/matlab_model_setup.jl
@@ -342,7 +342,7 @@ function setup_submodels(inputparams::MatlabInputParamsOld;
 
 		k0 = inputparams_itf["reactionRateConstant"]
 		Eak = inputparams_itf["activationEnergyOfReaction"]
-		am_params[:reaction_rate_constant_func] = (c, T) -> compute_reaction_rate_constant(c, T, k0, Eak)
+		am_params[:reaction_rate_constant_func] = (T) -> arrhenius(T, k0, Eak)
 
 		funcname = inputparams_itf["openCircuitPotential"]["functionname"] # This matlab parameter must have been converted from function handle to string before call
 		func = getfield(BattMo, Symbol(funcname))

--- a/src/models/activematerial.jl
+++ b/src/models/activematerial.jl
@@ -311,9 +311,14 @@ end
 		diff_func = model.system.params[:diff_func]
 
 		cmax = model.system.params[:maximum_concentration]
-		Ea = model.system.params[:activation_energy_of_diffusion]
-		setting_temperature_dependence = get(model.system.params, :setting_temperature_dependence, nothing)
+		setting_temperature_dependence = model.system.params[:setting_temperature_dependence]
 		refT = 298.15
+
+		if haskey(model.system.params, :activation_energy_of_diffusion)
+			Ea = model.system.params[:activation_energy_of_diffusion]
+		else
+			Ea = nothing
+		end
 
 		if Jutul.haskey(model.system.params, :diff_funcexp)
 			theta0   = model.system.params[:theta0]
@@ -325,17 +330,17 @@ end
 
 			if Jutul.haskey(model.system.params, :diff_funcexp)
 
-				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax), Ea, setting_temperature_dependence)
+				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax); Ea, dependent = setting_temperature_dependence)
 
 			elseif Jutul.haskey(model.system.params, :diff_funcdata)
 
-				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell] / cmax), Ea, setting_temperature_dependence)
+				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell] / cmax); Ea, dependent = setting_temperature_dependence)
 
 			elseif Jutul.haskey(model.system.params, :diff_funcconstant)
-				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func, Ea, setting_temperature_dependence)
+				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func; Ea, dependent = setting_temperature_dependence)
 			else
 
-				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax), Ea, setting_temperature_dependence)
+				@inbounds DiffusionCoefficient[cell] = temperature_dependent(Temperature[cell], diff_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax); Ea, dependent = setting_temperature_dependence)
 
 			end
 		end
@@ -350,7 +355,7 @@ end
 		Temperature,
 		ix) where {label, D, T, Di}
 		rate_func = model.system.params[:reaction_rate_constant_func]
-		Eak = model.system.params[:activation_energy_of_reaction]
+		Ea = model.system.params[:activation_energy_of_reaction]
 		setting_temperature_dependence = model.system.params[:setting_temperature_dependence]
 
 		refT = 298.15
@@ -359,17 +364,17 @@ end
 
 			if Jutul.haskey(model.system.params, :ecd_funcexp)
 
-				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax), Eak, setting_temperature_dependence)
+				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell], Temperature[cell]); Ea, dependent = setting_temperature_dependence)
 
 			elseif Jutul.haskey(model.system.params, :ecd_funcdata)
 
-				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell] / cmax), Eak, setting_temperature_dependence)
+				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell] / cmax); Ea, dependent = setting_temperature_dependence)
 
 			elseif Jutul.haskey(model.system.params, :ecd_funcconstant)
-				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func, Eak, setting_temperature_dependence)
+				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func; Ea, dependent = setting_temperature_dependence)
 			else
 
-				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell], Temperature[cell], refT, cmax), Eak, setting_temperature_dependence)
+				@inbounds ReactionRateConstant[cell] = temperature_dependent(Temperature[cell], rate_func(SurfaceConcentration[cell], Temperature[cell]); Ea, dependent = setting_temperature_dependence)
 
 			end
 		end

--- a/src/models/activematerial.jl
+++ b/src/models/activematerial.jl
@@ -355,11 +355,11 @@ end
 
 			if Jutul.haskey(model.system.params, :ecd_funcconstant)
 
-				@inbounds ReactionRateConstant[cell] = compute_reaction_rate_constant(SurfaceConcentration[cell], Temperature[cell], rate_func, Eak)
+				@inbounds ReactionRateConstant[cell] = arrhenius(Temperature[cell], rate_func, Eak)
 
 			else
 
-				@inbounds ReactionRateConstant[cell] = compute_reaction_rate_constant(SurfaceConcentration[cell], Temperature[cell], rate_func(SurfaceConcentration[cell], refT), Eak)
+				@inbounds ReactionRateConstant[cell] = arrhenius(Temperature[cell], rate_func(SurfaceConcentration[cell], refT), Eak)
 
 			end
 		end

--- a/src/models/full_battery_models/intercalation_battery.jl
+++ b/src/models/full_battery_models/intercalation_battery.jl
@@ -397,13 +397,14 @@ function setup_active_material(model::IntercalationBattery, name::Symbol, input,
 		am_params[:ocp_func] = interpolation_object
 	end
 
-	T        = input.cycling_protocol["InitialTemperature"]
+	refT     = 298.15
+	T        = get(input.cycling_protocol, "AmbientTemperature", refT)
 	SOC_init = input.cycling_protocol["InitialStateOfCharge"]
 
 	theta0   = inputparams_active_material["StoichiometricCoefficientAtSOC0"]
 	theta100 = inputparams_active_material["StoichiometricCoefficientAtSOC100"]
 	cmax     = inputparams_active_material["MaximumConcentration"]
-	refT     = 298.15
+
 
 	theta = SOC_init * (theta100 - theta0) + theta0
 	c     = theta * cmax
@@ -521,7 +522,8 @@ function set_parameters(model::IntercalationBattery, input
 
 	parameters = Dict{Symbol, Any}()
 
-	T0 = cycling_protocol["InitialTemperature"]
+	refT = 298.15
+	T = get(cycling_protocol, "AmbientTemperature", refT)
 
 	if haskey(model.settings, "CurrentCollectors")
 
@@ -544,7 +546,7 @@ function set_parameters(model::IntercalationBattery, input
 	inputparams_neam = cell_parameters["NegativeElectrode"]["ActiveMaterial"]
 
 	prm_neam[:Conductivity] = compute_effective_conductivity(multimodel[:NeAm], cell_parameters["NegativeElectrode"])
-	prm_neam[:Temperature] = T0
+	prm_neam[:Temperature] = T
 
 	if discretisation_type(multimodel[:NeAm]) == :P2Ddiscretization
 		# nothing to do
@@ -560,7 +562,7 @@ function set_parameters(model::IntercalationBattery, input
 	###############
 
 	prm_elyte = Dict{Symbol, Any}()
-	prm_elyte[:Temperature] = T0
+	prm_elyte[:Temperature] = T
 	prm_elyte[:BruggemanCoefficient] = cell_parameters["Separator"]["BruggemanCoefficient"]
 
 
@@ -574,7 +576,7 @@ function set_parameters(model::IntercalationBattery, input
 	inputparams_peam = cell_parameters["PositiveElectrode"]["ActiveMaterial"]
 
 	prm_peam[:Conductivity] = compute_effective_conductivity(multimodel[:PeAm], cell_parameters["PositiveElectrode"])
-	prm_peam[:Temperature] = T0
+	prm_peam[:Temperature] = T
 
 
 	if discretisation_type(multimodel[:PeAm]) == :P2Ddiscretization
@@ -891,7 +893,8 @@ function setup_initial_state(input, model::IntercalationBattery)
 
 	include_cc = haskey(model.settings, "CurrentCollectors")
 
-	T        = input.cycling_protocol["InitialTemperature"]
+	refT     = 298.15
+	T        = get(input.cycling_protocol, "AmbientTemperature", refT)
 	SOC_init = input.cycling_protocol["InitialStateOfCharge"]
 
 	function setup_init_am(name, multimodel)

--- a/src/models/full_battery_models/intercalation_battery.jl
+++ b/src/models/full_battery_models/intercalation_battery.jl
@@ -324,6 +324,7 @@ function setup_active_material(model::IntercalationBattery, name::Symbol, input,
 	am_params[:volume_fraction] = vf
 	am_params[:volume_fractions] = vfs
 	am_params[:effective_density] = eff_dens
+
 	am_params[:n_charge_carriers] = inputparams_active_material["NumberOfElectronsTransfered"]
 	am_params[:maximum_concentration] = inputparams_active_material["MaximumConcentration"]
 	am_params[:volumetric_surface_area] = inputparams_active_material["VolumetricSurfaceArea"]
@@ -331,12 +332,11 @@ function setup_active_material(model::IntercalationBattery, name::Symbol, input,
 	am_params[:theta100] = inputparams_active_material["StoichiometricCoefficientAtSOC100"]
 	am_params[:activation_energy_of_reaction] = inputparams_active_material["ActivationEnergyOfReaction"]
 
-	if haskey(model.settings, "ButlerVolmer") && model.settings["ButlerVolmer"] == "Chayambuka"
-		am_params[:setting_butler_volmer] = "Chayambuka"
+	am_params[:setting_temperature_dependence] = get(model.settings, "TemperatureDependence", nothing)
+	am_params[:setting_butler_volmer] = get(model.settings, "ButlerVolmer", nothing)
 
-	else
-		am_params[:setting_butler_volmer] = "Generic"
-
+	if am_params[:setting_temperature_dependence] == "Arrhenius"
+		am_params[:activation_energy_of_diffusion] = inputparams_active_material["ActivationEnergyOfDiffusion"]
 	end
 
 	if isa(inputparams_active_material["ReactionRateConstant"], Real)

--- a/src/models/ocp.jl
+++ b/src/models/ocp.jl
@@ -136,7 +136,7 @@ function computeOCP_Graphite_Xu2015(c, T, refT, cmax)
 	refT  = 298.15
 	theta = c ./ cmax
 
-	data1 = [                                                             0.00 1.28683
+	data1 = [                                                                  0.00 1.28683
 		0.01 0.65272
 		0.02 0.52621
 		0.03 0.44128
@@ -173,7 +173,7 @@ function computeOCP_Graphite_Xu2015(c, T, refT, cmax)
 
 	refOCP = itp_refOCP(theta)
 
-	data2 = [                                                             0.01049 3.00E-04
+	data2 = [                                                                  0.01049 3.00E-04
 		0.03146 2.47E-04
 		0.05244 1.95E-04
 		0.07711 1.33E-04
@@ -308,18 +308,6 @@ function computeOCP_NMC111(c, T, refT, cmax)
 	ocp    = refOCP + (T - refT) * dUdT
 
 	return ocp
-
-end
-
-## Defines standard exchange current density
-
-function compute_reaction_rate_constant(c, T, k0, Eak)
-
-	F = FARADAY_CONSTANT
-	refT = 298.15
-
-	val = k0 .* exp(-Eak ./ F .* (1.0 ./ T - 1 / refT))
-	return val
 
 end
 

--- a/src/models/temperature_dependence.jl
+++ b/src/models/temperature_dependence.jl
@@ -1,0 +1,11 @@
+""" Arrhenius model for temperature dependence of diffusion coefficients and reaction rates
+"""
+function arrhenius(T, A0, Ea)
+
+	F = FARADAY_CONSTANT
+	refT = 298.15
+
+	val = A0 .* exp(-Ea ./ F .* (1.0 ./ T - 1 / refT))
+	return val
+
+end

--- a/src/models/temperature_dependence.jl
+++ b/src/models/temperature_dependence.jl
@@ -9,3 +9,14 @@ function arrhenius(T, A0, Ea)
 	return val
 
 end
+
+function temperature_dependent(T, A0, Ea, dependent = nothing)
+
+	if dependent == "Arrhenius"
+		val = arrhenius(T, A0, Ea)
+	else
+		val = A0
+	end
+	return val
+
+end

--- a/src/models/temperature_dependence.jl
+++ b/src/models/temperature_dependence.jl
@@ -10,7 +10,7 @@ function arrhenius(T, A0, Ea)
 
 end
 
-function temperature_dependent(T, A0, Ea, dependent = nothing)
+function temperature_dependent(T, A0; Ea = nothing, dependent = nothing)
 
 	if dependent == "Arrhenius"
 		val = arrhenius(T, A0, Ea)

--- a/src/old_model_setup/model_setup.jl
+++ b/src/old_model_setup/model_setup.jl
@@ -654,7 +654,7 @@ function setup_submodels(inputparams::InputParamsOld;
 		k0  = inputparams_am["Interface"]["reactionRateConstant"]
 		Eak = inputparams_am["Interface"]["activationEnergyOfReaction"]
 
-		am_params[:reaction_rate_constant_func] = (c, T) -> compute_reaction_rate_constant(c, T, k0, Eak)
+		am_params[:reaction_rate_constant_func] = (T) -> arrhenius(T, k0, Eak)
 
 		if isa(inputparams_am["Interface"]["openCircuitPotential"], Real)
 			am_params[:ocp_funcconstant] = true

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -69,7 +69,7 @@ struct Simulation <: AbstractSimulation
 			# Here will come a validation function
 			model_settings = model.settings
 			cell_parameters_is_valid = validate_parameter_set(cell_parameters, model_settings)
-			cycling_protocol_is_valid = validate_parameter_set(cycling_protocol)
+			cycling_protocol_is_valid = validate_parameter_set(cycling_protocol, model_settings)
 			simulation_settings_is_valid = validate_parameter_set(simulation_settings, model_settings)
 
 			if cell_parameters_is_valid && cycling_protocol_is_valid && simulation_settings_is_valid

--- a/src/simulation/simulation.jl
+++ b/src/simulation/simulation.jl
@@ -591,9 +591,9 @@ function get_scalings(model, parameters)
 		c_a = 0.5 * cmax
 
 		if isa(rate_func, Real)
-			R0 = compute_reaction_rate_constant(c_a, refT, rate_func, Eak)
+			R0 = arrhenius(refT, rate_func, Eak)
 		else
-			R0 = compute_reaction_rate_constant(c_a, refT, rate_func(c_a, refT), Eak)
+			R0 = arrhenius(refT, rate_func(c_a, refT), Eak)
 		end
 		c_e            = 1000.0
 		activematerial = model[elde].system


### PR DESCRIPTION
Both the electrode reaction rate and diffusion coefficient can now be chosen to be Arrhenius type temperature dependent by setting the model setting `"TemperatureDependence" = "Arrhenius"`. If the model setting is not defined, the Arrhenius submodel will not be used.

`"InitialTemperature"` cycling protocol parameter has been replaced by `"AmbientTemperature"` as the model doesn't represent a change in temperature. This parameter is required when the model setting `"TemperatureDependent"` has been set to "Arrhenius".

Required parameters for this submodel:
- cell parameters: electrode `"ActivationEnergyOfReaction"`, `"ActivationEnergyOfDiffusion"`
- cycling protocol: `"AmbientTemperature"`

get_schema for validation is also adapted.